### PR TITLE
Use SquareAnnotation to show signtures

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -98,6 +98,9 @@ class AnnotationFactory {
             return new ButtonWidgetAnnotation(parameters);
           case "Ch":
             return new ChoiceWidgetAnnotation(parameters);
+          // Can be removed when upgrading to 2.8
+          case "Sig":
+            return new SquareAnnotation(parameters);
         }
         warn(
           'Unimplemented widget field type "' +
@@ -807,14 +810,6 @@ class WidgetAnnotation extends Annotation {
     }
 
     data.readOnly = this.hasFieldFlag(AnnotationFieldFlag.READONLY);
-
-    // Hide signatures because we cannot validate them, and unset the fieldValue
-    // since it's (most likely) a `Dict` which is non-serializable and will thus
-    // cause errors when sending annotations to the main-thread (issue 10347).
-    if (data.fieldType === "Sig") {
-      data.fieldValue = null;
-      this.setFlags(AnnotationFlag.HIDDEN);
-    }
   }
 
   /**


### PR DESCRIPTION
Since we cannot upgrade to 2.8 till ng2-pdf-viewer is ready, we cannot use the native pdfjs signature widget.

Note: please do not merge!